### PR TITLE
fix: corruption for new recruits

### DIFF
--- a/scripts/scr_recruit_data/scr_recruit_data.gml
+++ b/scripts/scr_recruit_data/scr_recruit_data.gml
@@ -79,7 +79,7 @@ function planet_training_sequence(local_apothecary_points){
 
 	        var recruit_chance = 999;
 	        var aspirant = 0;
-	        var new_recruit_corruption = 10;
+	        var new_recruit_corruption = 0;
 	        var months_to_neo = 72;
 	        var dista = 0;
 	        var onceh = 0;


### PR DESCRIPTION

## Description of changes
- This change fixes a typo with recruitment causing scouts to always have 10 corruption that cannot be reduced regardless of the training method.
## Reasons for changes
- 
## Related links
-
## How have you tested your changes?
- [Y] Compile
- [Y] New game
- [Y] Next turn
- [Y] Space Travel
- [Y] Ground Battle

<!--- PR title format should be "<type>(<optional-scope>): <Short summary>" -->
<!--- Commit types can be found at https://github.com/pvdlg/conventional-commit-types?tab=readme-ov-file#commit-types -->
<!--- You can add "@sourcery-ai" into the title, so that the bot auto-generates a title -->
<!--- Related links: other PRs, Discord bug reports, messages, threads, outside docs, etc. -->
<!--- Tests are not required, but each applicable may speed up the review of the PR -->
